### PR TITLE
fix for new bazel

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,18 +1,24 @@
 cc_library(
     name = "main-jni-lib",
     srcs = [
-        "@local_jdk//:jni_header",
-        "@local_jdk//:jni_md_header-linux",
-        "Main.cc"
-        ],
-    hdrs = [ "Main.h" ],
-    includes = [ "external/local_jdk/include", "external/local_jdk/include/linux" ],
+        "Main.cc",
+        "Main.h",
+    ],
+    hdrs = [
+        "@bazel_tools//tools/jdk:jni_header",
+        "@bazel_tools//tools/jdk:jni_md_header-linux",
+    ],
+    includes = [
+        "external/bazel_tools/tools/jdk/include",
+        "external/bazel_tools/tools/jdk/include/linux",
+    ],
+    alwayslink = True,
 )
 
 cc_binary(
     name = "libmain-jni.so",
     deps = [ ":main-jni-lib" ],
-    linkshared = 1,
+    linkshared = True,
 )
 
 java_binary(
@@ -22,4 +28,3 @@ java_binary(
     data = [ ":libmain-jni.so" ],
     jvm_flags = [ "-Djava.library.path=." ],
 )
-


### PR DESCRIPTION
I added the `alwayslink = True` to the `cc_library` so that symbols are exported in the `cc_binary`.